### PR TITLE
Follow links when walking through folders.

### DIFF
--- a/autobgch/bgch_libs/bgch_core.py
+++ b/autobgch/bgch_libs/bgch_core.py
@@ -108,7 +108,7 @@ class BgChCore:
 
     def __rand_picpath(self):
         allimgs = []
-        for (root, subFolders, filenames) in os.walk(self.__bg_dir):
+        for (root, subFolders, filenames) in os.walk(self.__bg_dir, followlinks=True):
             allimgs += list(filter(is_image, map(lambda arg: os.path.join(root, \
                 arg), filenames)))
 


### PR DESCRIPTION
I have wallpaper images in different folders so I created symbolic links under one folder and made that folder as `bg_dir`, but unfortunately autobgch cannot follow links. So I made this PR.
